### PR TITLE
Planner UI (Step 7B): Current/Hotel start, radius & detour, plan-day integration

### DIFF
--- a/app-main.js
+++ b/app-main.js
@@ -115,6 +115,7 @@ class SimpleNavigation {
     this.setupSearch();
     this.setupTripGeneration();
     this.setupVoiceButton();
+    this.setupPlannerUI();
   }
 
   setupSearch() {
@@ -338,6 +339,212 @@ class SimpleNavigation {
           isListening = false;
           voiceBtn.classList.remove('listening');
           voiceBtn.querySelector('.voice-text').textContent = 'Press & Hold to Speak';
+        }
+      });
+    }
+  }
+
+  setupPlannerUI() {
+    // Toggle start source buttons
+    const btnCurrent = document.getElementById('btnStartCurrent');
+    const btnHotel = document.getElementById('btnStartHotel');
+    const hotelRow = document.getElementById('hotelRow');
+    
+    if (btnCurrent && btnHotel && hotelRow) {
+      btnCurrent.addEventListener('click', () => {
+        btnCurrent.classList.add('active');
+        btnHotel.classList.remove('active');
+        hotelRow.style.display = 'none';
+      });
+      
+      btnHotel.addEventListener('click', () => {
+        btnHotel.classList.add('active');
+        btnCurrent.classList.remove('active');
+        hotelRow.style.display = 'flex';
+      });
+    }
+    
+    // Update slider value displays
+    const nearRadius = document.getElementById('nearRadius');
+    const nearRadiusVal = document.getElementById('nearRadiusVal');
+    if (nearRadius && nearRadiusVal) {
+      nearRadius.addEventListener('input', () => {
+        nearRadiusVal.textContent = nearRadius.value;
+      });
+    }
+    
+    const detourMin = document.getElementById('detourMin');
+    const detourMinVal = document.getElementById('detourMinVal');
+    if (detourMin && detourMinVal) {
+      detourMin.addEventListener('input', () => {
+        detourMinVal.textContent = detourMin.value;
+      });
+    }
+    
+    // Plan Day button handler
+    const btnPlanDay = document.getElementById('btnPlanDay');
+    if (btnPlanDay) {
+      btnPlanDay.addEventListener('click', async () => {
+        const resultsDiv = document.getElementById('planner-results');
+        if (!resultsDiv) return;
+        
+        resultsDiv.innerHTML = '<div style="padding:20px; text-align:center;">🧠 Planning your day...</div>';
+        btnPlanDay.disabled = true;
+        btnPlanDay.textContent = 'Planning...';
+        
+        try {
+          const lang = document.documentElement.getAttribute('data-lang') || 'he';
+          const isHotelMode = btnHotel && btnHotel.classList.contains('active');
+          
+          let body = {
+            mode: 'drive',
+            near_origin: {
+              radius_km: parseInt(nearRadius?.value || '5'),
+              types: ['tourist_attraction', 'viewpoint', 'museum'],
+              min_rating: 4.3,
+              open_now: false,
+              limit: 8
+            },
+            sar: {
+              query: 'viewpoint|restaurant|ice_cream',
+              max_detour_min: parseInt(detourMin?.value || '15'),
+              max_results: 12
+            }
+          };
+          
+          if (isHotelMode) {
+            // Hotel mode: use origin_query
+            const hotelInput = document.getElementById('hotelInput');
+            const hotelName = hotelInput?.value?.trim();
+            if (!hotelName) {
+              resultsDiv.innerHTML = '<div style="padding:20px; color:#d32f2f;">⚠️ Please enter a hotel name</div>';
+              btnPlanDay.disabled = false;
+              btnPlanDay.textContent = document.querySelector('[data-i18n="planner.plan_day"]')?.textContent || 'Plan Day';
+              return;
+            }
+            body.origin_query = hotelName;
+          } else {
+            // Current location mode: use geolocation
+            try {
+              const pos = await new Promise((resolve, reject) => {
+                navigator.geolocation.getCurrentPosition(resolve, reject, {
+                  enableHighAccuracy: false,
+                  timeout: 10000,
+                  maximumAge: 300000
+                });
+              });
+              body.origin = {
+                lat: pos.coords.latitude,
+                lon: pos.coords.longitude
+              };
+            } catch (geoErr) {
+              console.error('Geolocation error:', geoErr);
+              resultsDiv.innerHTML = '<div style="padding:20px; color:#d32f2f;">⚠️ Could not get your location. Please enable location services or use hotel mode.</div>';
+              btnPlanDay.disabled = false;
+              btnPlanDay.textContent = document.querySelector('[data-i18n="planner.plan_day"]')?.textContent || 'Plan Day';
+              return;
+            }
+          }
+          
+          // Optional destination
+          const destInput = document.getElementById('destInput');
+          const destQuery = destInput?.value?.trim();
+          if (destQuery) {
+            body.dest_query = destQuery;
+          }
+          
+          // Call backend API
+          const response = await fetch('https://roamwise-backend-v2-971999716773.us-central1.run.app/planner/plan-day', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-lang': lang
+            },
+            credentials: 'include',
+            body: JSON.stringify(body)
+          });
+          
+          const data = await response.json();
+          
+          if (!data.ok || !data.plan) {
+            throw new Error(data.error || 'Plan failed');
+          }
+          
+          // Render results
+          const { plan } = data;
+          const { summary, timeline } = plan;
+          
+          let html = '<div class="header">';
+          html += `<div><strong>🗺️ Day Plan</strong></div>`;
+          if (summary.origin_name) {
+            html += `<div>📍 Starting from: ${summary.origin_name}</div>`;
+          }
+          html += `<div>🎯 Mode: ${summary.plan_mode} • POIs: ${summary.count}</div>`;
+          if (summary.near_origin_scanned) {
+            html += `<div>🔍 Near origin: ${summary.near_origin_count || 0} found</div>`;
+          }
+          if (summary.sar_scanned) {
+            html += `<div>🛣️ Along route: ${summary.sar_count || 0} found</div>`;
+          }
+          html += '</div>';
+          
+          if (timeline && timeline.length > 0) {
+            let cumMin = 0;
+            for (const leg of timeline) {
+              if (leg.to?.kind === 'poi') {
+                const eta = leg.eta_seconds ? Math.round(leg.eta_seconds / 60) : null;
+                cumMin = eta || cumMin;
+                
+                html += '<div class="poi">';
+                html += `<div><strong>${leg.to.name || 'POI'}</strong></div>`;
+                if (leg.to.rating) {
+                  html += `<div class="meta">⭐ ${leg.to.rating.toFixed(1)}`;
+                  if (leg.to.user_ratings_total) {
+                    html += ` (${leg.to.user_ratings_total} reviews)`;
+                  }
+                  html += '</div>';
+                }
+                if (eta !== null) {
+                  html += `<div class="meta">🕐 ETA: +${cumMin} min from start</div>`;
+                }
+                if (leg.to.detour_min !== undefined) {
+                  html += `<div class="meta">🔀 Detour: ${leg.to.detour_min} min</div>`;
+                }
+                html += '</div>';
+              }
+            }
+          } else {
+            html += '<div style="padding:20px;">No POIs found. Try adjusting the radius or destination.</div>';
+          }
+          
+          // Add SAR results if present
+          if (summary.sar_results && summary.sar_results.length > 0) {
+            html += '<hr><div class="header"><strong>🛣️ Along-Route Discoveries</strong></div>';
+            for (const sar of summary.sar_results.slice(0, 6)) {
+              html += '<div class="poi">';
+              html += `<div><strong>${sar.name || 'Place'}</strong></div>`;
+              if (sar.rating) {
+                html += `<div class="meta">⭐ ${sar.rating.toFixed(1)}`;
+                if (sar.user_ratings_total) {
+                  html += ` (${sar.user_ratings_total} reviews)`;
+                }
+                html += '</div>';
+              }
+              if (sar.detour_min !== undefined) {
+                html += `<div class="meta">🔀 Detour: ${sar.detour_min} min</div>`;
+              }
+              html += '</div>';
+            }
+          }
+          
+          resultsDiv.innerHTML = html;
+          
+        } catch (error) {
+          console.error('Planner error:', error);
+          resultsDiv.innerHTML = `<div style="padding:20px; color:#d32f2f;">❌ Error: ${error.message || 'Failed to plan day'}</div>`;
+        } finally {
+          btnPlanDay.disabled = false;
+          btnPlanDay.textContent = document.querySelector('[data-i18n="planner.plan_day"]')?.textContent || 'Plan Day';
         }
       });
     }

--- a/app-main.js
+++ b/app-main.js
@@ -453,8 +453,8 @@ class SimpleNavigation {
             body.dest_query = destQuery;
           }
           
-          // Call backend API
-          const response = await fetch('https://roamwise-backend-v2-971999716773.us-central1.run.app/planner/plan-day', {
+          // Call backend API via proxy
+          const response = await fetch('https://roamwise-proxy-971999716773.us-central1.run.app/planner/plan-day', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,10 @@
+{
+  "planner.start_from": "Start from",
+  "planner.my_location": "📍 My location",
+  "planner.my_hotel": "🏨 My hotel",
+  "planner.hotel_name": "Hotel name",
+  "planner.destination": "Destination (optional)",
+  "planner.near_radius": "Nearby radius (km)",
+  "planner.detour_minutes": "Along-route max detour (min)",
+  "planner.plan_day": "Plan Day"
+}

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -1,0 +1,10 @@
+{
+  "planner.start_from": "נקודת התחלה",
+  "planner.my_location": "📍 המיקום שלי",
+  "planner.my_hotel": "🏨 המלון שלי",
+  "planner.hotel_name": "שם המלון",
+  "planner.destination": "יעד (לא חובה)",
+  "planner.near_radius": "רדיוס בקרבת ההתחלה (ק\"מ)",
+  "planner.detour_minutes": "עיקוף מירבי לאורך המסלול (דק׳)",
+  "planner.plan_day": "תכנן יום"
+}

--- a/index.html
+++ b/index.html
@@ -457,6 +457,123 @@
       opacity: 1 !important;
       visibility: visible !important;
     }
+
+    /* Planner Controls (Step 7B) */
+    .planner-controls {
+      background: white;
+      padding: 20px;
+      border-radius: 12px;
+      margin: 20px 0;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .planner-controls .row {
+      margin: 12px 0;
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .planner-controls .row label {
+      font-weight: 500;
+      min-width: 120px;
+      color: #333;
+    }
+
+    .seg {
+      display: inline-flex;
+      border: 1px solid #ccc;
+      border-radius: 10px;
+      overflow: hidden;
+    }
+
+    .seg-btn {
+      padding: 8px 16px;
+      border: 0;
+      background: #f4f4f4;
+      cursor: pointer;
+      transition: all 0.2s;
+      font-size: 14px;
+    }
+
+    .seg-btn:hover {
+      background: #e8e8e8;
+    }
+
+    .seg-btn.active {
+      background: #1976d2;
+      color: #fff;
+    }
+
+    .sliders {
+      flex-direction: column;
+      align-items: stretch !important;
+      gap: 16px;
+    }
+
+    .sliders .slider {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .sliders .slider label {
+      min-width: auto;
+      flex: 1;
+    }
+
+    .sliders .slider input[type="range"] {
+      flex: 2;
+      min-width: 150px;
+    }
+
+    .sliders .slider span {
+      min-width: 30px;
+      font-weight: 600;
+      color: #1976d2;
+    }
+
+    .planner-results {
+      background: white;
+      border-radius: 12px;
+      margin: 20px 0;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+      max-height: 600px;
+      overflow-y: auto;
+    }
+
+    .planner-results .poi {
+      padding: 16px;
+      border-bottom: 1px solid #eee;
+    }
+
+    .planner-results .poi:last-child {
+      border-bottom: none;
+    }
+
+    .poi .meta {
+      font-size: 13px;
+      opacity: 0.7;
+      margin-top: 4px;
+    }
+
+    .planner-results .header {
+      background: #f8fafc;
+      padding: 16px;
+      border-bottom: 2px solid #e2e8f0;
+    }
+
+    .planner-results .header div {
+      margin: 4px 0;
+      font-size: 14px;
+    }
+
+    .planner-results hr {
+      margin: 12px 0;
+      border: none;
+      border-top: 1px solid #e2e8f0;
+    }
   </style>
   <script type="module" crossorigin src="/roamwise-app/assets/index.simple-BMXtb2UU.js"></script>
 <link rel="manifest" href="/roamwise-app/manifest.webmanifest"><script id="vite-plugin-pwa:register-sw" src="/roamwise-app/registerSW.js"></script></head>
@@ -549,7 +666,50 @@
             🤖 Generate Smart Trip
           </button>
         </div>
-        
+
+        <!-- Planner Controls (Step 7B) -->
+        <div id="planner-controls" class="planner-controls">
+          <h3 style="margin-bottom: 16px;">🗺️ Day Planner</h3>
+
+          <div class="row">
+            <label data-i18n="planner.start_from">Start from</label>
+            <div class="seg">
+              <button id="btnStartCurrent" class="seg-btn active" data-i18n="planner.my_location">📍 My location</button>
+              <button id="btnStartHotel" class="seg-btn" data-i18n="planner.my_hotel">🏨 My hotel</button>
+            </div>
+          </div>
+
+          <div class="row" id="hotelRow" style="display:none;">
+            <label data-i18n="planner.hotel_name">Hotel name</label>
+            <input id="hotelInput" type="text" placeholder="Hotel Splendido…" style="flex:1; padding:8px; border:1px solid #ccc; border-radius:8px;" />
+          </div>
+
+          <div class="row">
+            <label data-i18n="planner.destination">Destination (optional)</label>
+            <input id="destInput" type="text" placeholder="Dolomites / Sirmione…" style="flex:1; padding:8px; border:1px solid #ccc; border-radius:8px;" />
+          </div>
+
+          <div class="row sliders">
+            <div class="slider">
+              <label for="nearRadius" data-i18n="planner.near_radius">Nearby radius (km)</label>
+              <input id="nearRadius" type="range" min="1" max="30" step="1" value="5" />
+              <span id="nearRadiusVal">5</span>
+            </div>
+            <div class="slider">
+              <label for="detourMin" data-i18n="planner.detour_minutes">Along-route max detour (min)</label>
+              <input id="detourMin" type="range" min="5" max="30" step="1" value="15" />
+              <span id="detourMinVal">15</span>
+            </div>
+          </div>
+
+          <div class="row">
+            <button id="btnPlanDay" class="primary" data-i18n="planner.plan_day" style="width:100%; padding:12px; background:#1976d2; color:white; border:none; border-radius:8px; font-size:16px; cursor:pointer;">Plan Day</button>
+          </div>
+        </div>
+
+        <!-- Planner Results -->
+        <div id="planner-results" class="planner-results"></div>
+
         <div id="enhancedTripDisplay" class="trip-results">
           <div class="trip-result">
             <h3>🗺️ AI Trip Planning</h3>

--- a/scripts/test-ui-7b.sh
+++ b/scripts/test-ui-7b.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Step 7B UI Test ==="
+echo ""
+
+# Check if required files exist
+echo "--- Checking Files ---"
+
+if [ ! -f "index.html" ]; then
+  echo "❌ FAIL: index.html not found"
+  exit 1
+fi
+
+if [ ! -f "app-main.js" ]; then
+  echo "❌ FAIL: app-main.js not found"
+  exit 1
+fi
+
+if [ ! -f "i18n/en.json" ]; then
+  echo "❌ FAIL: i18n/en.json not found"
+  exit 1
+fi
+
+if [ ! -f "i18n/he.json" ]; then
+  echo "❌ FAIL: i18n/he.json not found"
+  exit 1
+fi
+
+echo "✅ All required files exist"
+echo ""
+
+# Check HTML elements
+echo "--- Checking HTML Elements ---"
+
+if ! grep -q 'id="btnStartCurrent"' index.html; then
+  echo "❌ FAIL: btnStartCurrent not found in HTML"
+  exit 1
+fi
+
+if ! grep -q 'id="btnStartHotel"' index.html; then
+  echo "❌ FAIL: btnStartHotel not found in HTML"
+  exit 1
+fi
+
+if ! grep -q 'id="hotelInput"' index.html; then
+  echo "❌ FAIL: hotelInput not found in HTML"
+  exit 1
+fi
+
+if ! grep -q 'id="destInput"' index.html; then
+  echo "❌ FAIL: destInput not found in HTML"
+  exit 1
+fi
+
+if ! grep -q 'id="nearRadius"' index.html; then
+  echo "❌ FAIL: nearRadius slider not found in HTML"
+  exit 1
+fi
+
+if ! grep -q 'id="detourMin"' index.html; then
+  echo "❌ FAIL: detourMin slider not found in HTML"
+  exit 1
+fi
+
+if ! grep -q 'id="btnPlanDay"' index.html; then
+  echo "❌ FAIL: btnPlanDay not found in HTML"
+  exit 1
+fi
+
+if ! grep -q 'id="planner-results"' index.html; then
+  echo "❌ FAIL: planner-results container not found in HTML"
+  exit 1
+fi
+
+echo "✅ All required HTML elements present"
+echo ""
+
+# Check data-i18n attributes
+echo "--- Checking i18n Attributes ---"
+
+if ! grep -q 'data-i18n="planner.start_from"' index.html; then
+  echo "❌ FAIL: data-i18n planner.start_from not found"
+  exit 1
+fi
+
+if ! grep -q 'data-i18n="planner.my_location"' index.html; then
+  echo "❌ FAIL: data-i18n planner.my_location not found"
+  exit 1
+fi
+
+if ! grep -q 'data-i18n="planner.my_hotel"' index.html; then
+  echo "❌ FAIL: data-i18n planner.my_hotel not found"
+  exit 1
+fi
+
+if ! grep -q 'data-i18n="planner.plan_day"' index.html; then
+  echo "❌ FAIL: data-i18n planner.plan_day not found"
+  exit 1
+fi
+
+echo "✅ All i18n attributes present"
+echo ""
+
+# Check JavaScript implementation
+echo "--- Checking JavaScript Implementation ---"
+
+if ! grep -q 'setupPlannerUI()' app-main.js; then
+  echo "❌ FAIL: setupPlannerUI() function not found in app-main.js"
+  exit 1
+fi
+
+if ! grep -q 'this.setupPlannerUI()' app-main.js; then
+  echo "❌ FAIL: setupPlannerUI() not called in initialization"
+  exit 1
+fi
+
+if ! grep -q 'btnStartCurrent' app-main.js; then
+  echo "❌ FAIL: btnStartCurrent handling not found in JS"
+  exit 1
+fi
+
+if ! grep -q 'btnStartHotel' app-main.js; then
+  echo "❌ FAIL: btnStartHotel handling not found in JS"
+  exit 1
+fi
+
+if ! grep -q 'navigator.geolocation' app-main.js; then
+  echo "❌ FAIL: geolocation API not used for current location"
+  exit 1
+fi
+
+if ! grep -q 'roamwise-backend-v2.*planner/plan-day' app-main.js; then
+  echo "❌ FAIL: /planner/plan-day endpoint not called"
+  exit 1
+fi
+
+if ! grep -q 'origin_query' app-main.js; then
+  echo "❌ FAIL: origin_query (hotel mode) not implemented"
+  exit 1
+fi
+
+if ! grep -q 'near_origin' app-main.js; then
+  echo "❌ FAIL: near_origin parameter not sent"
+  exit 1
+fi
+
+if ! grep -q 'radius_km' app-main.js; then
+  echo "❌ FAIL: radius_km not configured"
+  exit 1
+fi
+
+if ! grep -q 'max_detour_min' app-main.js; then
+  echo "❌ FAIL: max_detour_min (SAR) not configured"
+  exit 1
+fi
+
+echo "✅ JavaScript implementation correct"
+echo ""
+
+# Check i18n translations
+echo "--- Checking i18n Translations ---"
+
+# Check English
+if ! jq -e '.["planner.start_from"]' i18n/en.json > /dev/null 2>&1; then
+  echo "❌ FAIL: planner.start_from not in en.json"
+  exit 1
+fi
+
+if ! jq -e '.["planner.plan_day"]' i18n/en.json > /dev/null 2>&1; then
+  echo "❌ FAIL: planner.plan_day not in en.json"
+  exit 1
+fi
+
+# Check Hebrew
+if ! jq -e '.["planner.start_from"]' i18n/he.json > /dev/null 2>&1; then
+  echo "❌ FAIL: planner.start_from not in he.json"
+  exit 1
+fi
+
+if ! jq -e '.["planner.plan_day"]' i18n/he.json > /dev/null 2>&1; then
+  echo "❌ FAIL: planner.plan_day not in he.json"
+  exit 1
+fi
+
+echo "✅ i18n translations present"
+echo ""
+
+# Check CSS
+echo "--- Checking CSS Styles ---"
+
+if ! grep -q '\.planner-controls' index.html; then
+  echo "❌ FAIL: .planner-controls CSS not found"
+  exit 1
+fi
+
+if ! grep -q '\.seg-btn' index.html; then
+  echo "❌ FAIL: .seg-btn CSS not found"
+  exit 1
+fi
+
+if ! grep -q '\.planner-results' index.html; then
+  echo "❌ FAIL: .planner-results CSS not found"
+  exit 1
+fi
+
+echo "✅ CSS styles present"
+echo ""
+
+echo "✅ ALL TESTS PASSED: Step 7B UI Implementation Complete"
+echo ""
+echo "Manual testing steps:"
+echo "1. Open the app in a browser"
+echo "2. Navigate to Trip View"
+echo "3. Test 'My Location' mode (allow geolocation)"
+echo "4. Test 'My Hotel' mode with hotel name"
+echo "5. Adjust radius and detour sliders"
+echo "6. Click 'Plan Day' and verify results display"
+echo "7. Test EN/HE language toggle"
+exit 0

--- a/scripts/test-ui-7b.sh
+++ b/scripts/test-ui-7b.sh
@@ -130,8 +130,8 @@ if ! grep -q 'navigator.geolocation' app-main.js; then
   exit 1
 fi
 
-if ! grep -q 'roamwise-backend-v2.*planner/plan-day' app-main.js; then
-  echo "❌ FAIL: /planner/plan-day endpoint not called"
+if ! grep -q 'roamwise-proxy.*planner/plan-day' app-main.js; then
+  echo "❌ FAIL: /planner/plan-day endpoint not called via proxy"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Step 7B implementation: Frontend UI for the day planner feature.

## Changes
- ✅ Added planner controls to Trip View (index.html)
  - Segmented control for start source (📍 My Location / 🏨 My Hotel)
  - Hotel name input field (shown in hotel mode)
  - Optional destination input
  - Radius slider (1-30 km)
  - Detour slider (5-30 min)
  - Plan Day button
  - Results container

- ✅ Implemented setupPlannerUI() in app-main.js
  - Toggle between current location and hotel modes
  - Geolocation API integration for current location
  - Hotel name resolution via origin_query
  - Dynamic request building with near_origin and sar parameters
  - Integration with /planner/plan-day backend endpoint
  - Results rendering with POI timeline and SAR discoveries

- ✅ Added i18n translations (i18n/en.json, i18n/he.json)
  - All planner UI strings for English and Hebrew

- ✅ Created automated test script (scripts/test-ui-7b.sh)
  - Verifies all HTML elements present
  - Checks data-i18n attributes
  - Validates JavaScript implementation
  - Confirms i18n translations exist
  - All tests passing ✅

## Backend Integration
- Endpoint: `https://roamwise-backend-v2-971999716773.us-central1.run.app/planner/plan-day`
- Request: near_origin params (radius_km, types, min_rating, limit)
- Request: sar params (query, max_detour_min, max_results)
- Response: plan.timeline with POIs and ETAs

## Testing
Run: `./scripts/test-ui-7b.sh`

Manual testing:
1. Open app in browser
2. Navigate to Trip View
3. Test current location mode (allow geolocation)
4. Test hotel mode with hotel name
5. Adjust sliders and verify they update
6. Click Plan Day and verify results display
7. Test EN/HE language toggle

## Related
- Depends on: Step 7A backend (already deployed)
- Part of: Day Planner feature set

🤖 Generated with [Claude Code](https://claude.ai/code)